### PR TITLE
Fix AUTO-TUNE best guess output to include threshold value

### DIFF
--- a/hivclustering/networkbuild.py
+++ b/hivclustering/networkbuild.py
@@ -745,7 +745,7 @@ def build_a_network(extra_arguments = None):
                 # No candidates with score >= 1.9, find best guess
                 best_guess = sorted (profile, key = lambda r : r[6], reverse = True)
                 selected_threshold = best_guess[0][0]
-                recommendation_status = f"Best guess (score {best_guess[0][6]:.3g})"
+                recommendation_status = f"Best guess {best_guess[0][0]:.5g} (score {best_guess[0][6]:.5g})"
 
         if run_settings.auto_prof is not None:
             print ("\t".join (["Threshold","Nodes","Edges","Clusters","LargestCluster","SecondLargestCluster","Score","Singletons","Recommended"]))

--- a/tests/test_autotune.py
+++ b/tests/test_autotune.py
@@ -189,9 +189,9 @@ seq19,seq20,0.0105
                 # Should provide a meaningful best guess with actual score, not default fallback
                 self.assertNotIn("best guess 1e-05 (score 0)", result.stderr,
                                "Should not fall back to default threshold when real candidates exist")
-                # Should see a meaningful best guess with score
-                self.assertRegex(result.stderr, r"best guess \(score \d+\.?\d*\)",
-                               "Should provide meaningful best guess with real score")
+                # Should see a meaningful best guess with threshold and score
+                self.assertRegex(result.stderr, r"best guess [\d\.e\-\+]+ \(score [\d\.e\-\+]+\)",
+                               "Should provide meaningful best guess with threshold and real score")
             else:
                 # In some cases it might successfully select a threshold
                 self.assertIn("Selected distance threshold", result.stderr,


### PR DESCRIPTION
## Summary
- Fixes AUTO-TUNE mode's "best guess" error message to include the threshold value
- Restores compatibility with existing parsing scripts

## Problem
The AUTO-TUNE mode (`-t auto`) was outputting incomplete error messages when it couldn't automatically determine a threshold. The "best guess" message was missing the actual threshold value:

**Before (broken):**
```
Could not automatically determine a distance threshold; no sufficiently strong outlier, best guess (score 1.02)
```

**After (fixed):**
```
Could not automatically determine a distance threshold; no sufficiently strong outlier, best guess 0.00201 (score 1.5)
```

## Solution
Updated the `recommendation_status` formatting in `networkbuild.py` line 748 to include both the threshold value and score in the output.

## Test plan
- [x] Updated unit tests to expect the corrected format
- [x] All tests pass
- [x] Format matches expected output for parsing scripts

🤖 Generated with [Claude Code](https://claude.ai/code)