### PR TITLE
Remove bioext from edgefiltering extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 sys.path.insert(0, join(split(abspath(__file__))[0], 'lib'))
 
 setup(name='hivclustering',
-      version="1.9.6",
+      version="1.9.7",
       description='HIV molecular clustering tools',
       author='Sergei Kosakovsky Pond',
       author_email='spond@ucsd.edu',
@@ -20,7 +20,7 @@ setup(name='hivclustering',
     ]},
     python_requires='>=3.10',
     extras_require={
-        'edgefiltering': ['bioext >= 0.21.0','hyphy-python >= 0.1.11','hppy >= 0.9.9'],
+        'edgefiltering': ['hyphy-python >= 0.1.11','hppy >= 0.9.9'],
     },
     scripts=[
         'scripts/hivnetworkcsv',


### PR DESCRIPTION
## Summary
- Remove `bioext` from the `edgefiltering` extras_require — it is not imported anywhere in hivclustering
- The edgefiltering code only uses `hppy` and `hyphy-python`
- This removes the transitive `pysam` dependency, fixing Python 3.14 compatibility
- Bump version to 1.9.7