### PR TITLE
Feature/sequence level attribute matching

### DIFF
--- a/scripts/hivnetworkannotate
+++ b/scripts/hivnetworkannotate
@@ -81,6 +81,7 @@ arguments.add_argument  ('-x', '--missing', help  = 'If desired, provide a value
 arguments.add_argument  ('-X', '--clear', help = 'Flush existing attributes', required = False, action = 'store_true')
 arguments.add_argument  ('-i', '--index',   help    = 'The name of the column that indexes records (patient ID); default is to index on the first column', type = str)
 arguments.add_argument  ('-r', '--inplace', help = 'Write attributes to the input file (cannot be stdin)', required = False, action = 'store_true')
+arguments.add_argument  ('-F', '--full-inject', help = 'Add nodes from the attributes file that are not already present in the network', required = False, action = 'store_true')
 
 input_group = arguments.add_mutually_exclusive_group(required=True)
 input_group.add_argument  ('-a', '--attributes',   help    = 'The JSON file with node attributes', type = argparse.FileType('r'))
@@ -215,6 +216,8 @@ for n in network_json["Nodes"]:
         if node_attribute_key in n:
             del n[node_attribute_key]  # Clear attributes if requested
 
+injected_nodes = []
+
 # Now match nodes by the key constructed from the input data
 for node_key, values in to_import.items():
     if node_key in nodes_indexed_by_id:  # Match by the constructed key
@@ -226,6 +229,38 @@ for node_key, values in to_import.items():
                     node_dict[field_names[k]] = store_this
                     if nodes_indexed_by_id[node_key]['id'] in uninjected_set[field_names[k]]:
                         uninjected_set[field_names[k]].remove(nodes_indexed_by_id[node_key]['id'])
+    elif import_settings.full_inject:  # If full-inject is enabled, construct a new node
+        new_node = {
+            "id": node_key,
+            node_attribute_key: {}
+        }
+        node_dict = new_node[node_attribute_key]
+        for k, val in values.items():
+            if k in field_transformations:
+                store_this = field_transformations[k](val)
+                if store_this is not None:
+                    node_dict[field_names[k]] = store_this
+        injected_nodes.append(new_node)
+
+if import_settings.full_inject and len(injected_nodes) > 0:
+    # 1. Record original mapping of old index -> node ID to remap edge indices
+    index_to_id = {i: node["id"] for i, node in enumerate(network_json["Nodes"])}
+    
+    # 2. Append newly injected nodes
+    network_json["Nodes"].extend(injected_nodes)
+    
+    # 3. Sort all nodes alphabetically by ID to take advantage of Front (prefix) compression
+    network_json["Nodes"] = sorted(network_json["Nodes"], key=lambda x: x["id"])
+    
+    # 4. Build mapping of node ID -> new index
+    id_to_new_index = {node["id"]: i for i, node in enumerate(network_json["Nodes"])}
+    
+    # 5. Remap Edges source/target indices to match the new sorted node order
+    for edge in network_json.get("Edges", []):
+        source_id = index_to_id[edge["source"]]
+        target_id = index_to_id[edge["target"]]
+        edge["source"] = id_to_new_index[source_id]
+        edge["target"] = id_to_new_index[target_id]
 
 print ("\nImport summary", file = sys.stderr)
 print ("\t Records in file  : %d" % total_records, file = sys.stderr)

--- a/scripts/hivnetworkannotate
+++ b/scripts/hivnetworkannotate
@@ -135,7 +135,7 @@ else:
 
     #Filter out items that don't have a label
     fields_file_json = {k : v for k,v in fields_file_json.items() if "label" in v.keys()}
-    field_settings = [[k, v["label"], v["type"], ""] for k,v in fields_file_json.items()]
+    field_settings = [[k, v["label"], v["type"], v.get("transform", "")] for k,v in fields_file_json.items()]
 
 
 for key_pair in field_settings:
@@ -158,15 +158,16 @@ for key_pair in field_settings:
 total_records = 0
 
 if import_settings.attributes: # JSON input
-    to_import = json.load (import_settings.attributes)
-    #If a list of items, then key by ehars_uid
-    to_import = {
-        construct_key(v, key_fields, key_delimiter): v
-        for v in to_import
-        if construct_key(v, key_fields, key_delimiter)
-    }
-    total_records = len(to_import)
-else: # TSV import
+    to_import_raw = json.load (import_settings.attributes)
+    to_import = {}
+    for v in to_import_raw:
+        key = construct_key(v, key_fields, key_delimiter)
+        if key:
+            if key not in to_import:
+                to_import[key] = []
+            to_import[key].append(v)
+    total_records = len(to_import_raw)
+else: # TSV/CSV import
     if import_settings.tab:
         csv_reader = csv.reader (import_settings.tab, delimiter = '\t')
     else:
@@ -176,10 +177,10 @@ else: # TSV import
 
     index_on = 0
     if import_settings.index:
-        index_on = fields.index (import_settings.index)
-        if index_on < 0:
+        idx = fields.index (import_settings.index)
+        if idx < 0:
             raise "Invalid field to index on (%s)" % import_settings.index
-        index_on = lambda L : L[index_on]
+        index_on = lambda L : L[idx]
     else:
         if import_settings.fields_file:
              indices = []
@@ -194,73 +195,171 @@ else: # TSV import
     try:
         for line in csv_reader:
             line_index = index_on (line)
-            to_import [line_index] = {}
-            total_records += 1
+            record = {}
             for i, k in enumerate (line):
-                if i != index_on:
-                     to_import [line_index][fields[i]] = k
+                record[fields[i]] = k
+            if line_index not in to_import:
+                to_import [line_index] = []
+            to_import [line_index].append(record)
+            total_records += 1
     except IndexError as e:
-        print (i, index_on, line, fields)
+        print (line, fields)
         raise
 
 id_mapper = lambda x: x
 
 nodes_indexed_by_id = {}
+nodes_by_full_id = {}
 # Index nodes by their constructed key, rather than their id
 for n in network_json["Nodes"]:
     node_key = construct_node_key_from_schema(n['id'],  key_fields, key_delimiter)
-    nodes_indexed_by_id[node_key] = n
+    if node_key in nodes_indexed_by_id:
+        nodes_indexed_by_id[node_key].append(n)
+    else:
+        nodes_indexed_by_id[node_key] = [n]
+        
+    nodes_by_full_id[n['id']] = n
     for f, s in uninjected_set.items():
         s.add(n['id'])  # Track uninjected nodes
     if import_settings.clear:
         if node_attribute_key in n:
             del n[node_attribute_key]  # Clear attributes if requested
 
+def compute_match_score(record, sequence_tokens, key_fields):
+    score = 0
+    for k, val in record.items():
+        if k not in key_fields:
+            val_str = str(val) if val is not None else ""
+            if val_str:
+                val_tokens = re.split(r'[|~]', val_str)
+                for token in val_tokens:
+                    if token and token in sequence_tokens:
+                        score += 1
+    return score
+
+def check_has_sequence(record):
+    seq_str = record.get('predq_clean_seq', '').upper()
+    if seq_str and seq_str not in ('', 'MISSING'):
+        return True
+    seq_len = record.get('predq_seq_len_clean', '0')
+    try:
+        if int(seq_len) > 0:
+            return True
+    except ValueError:
+        pass
+    return False
+
 injected_nodes = []
 
 # Now match nodes by the key constructed from the input data
-for node_key, values in to_import.items():
+for node_key, records in to_import.items():
     if node_key in nodes_indexed_by_id:  # Match by the constructed key
-        node_dict = ensure_key(nodes_indexed_by_id[node_key], node_attribute_key)
-        for k, val in values.items():
-            if k in field_transformations:
-                store_this = field_transformations[k](val)
-                if store_this is not None and node_dict is not None:
-                    node_dict[field_names[k]] = store_this
-                    if nodes_indexed_by_id[node_key]['id'] in uninjected_set[field_names[k]]:
-                        uninjected_set[field_names[k]].remove(nodes_indexed_by_id[node_key]['id'])
+        for n_object in nodes_indexed_by_id[node_key]:
+            node_dict = ensure_key(n_object, node_attribute_key)
+            
+            # Select the best record from the list of records for this node
+            node_id_tokens = set(re.split(r'[|~]', n_object['id']))
+            key_tokens = set(re.split(r'[|~]', node_key))
+            sequence_tokens = node_id_tokens - key_tokens
+            
+            best_record = None
+            max_score = -1
+            # Check for sequence-specific identifiers matching the node ID tokens
+            for record in records:
+                score = compute_match_score(record, sequence_tokens, key_fields)
+                if score > max_score:
+                    max_score = score
+                    best_record = record
+            
+            if best_record is None:
+                best_record = records[0]
+                
+            for k, val in best_record.items():
+                if k in field_transformations:
+                    store_this = field_transformations[k](val)
+                    if store_this is not None and node_dict is not None:
+                        node_dict[field_names[k]] = store_this
+                        if n_object['id'] in uninjected_set[field_names[k]]:
+                            uninjected_set[field_names[k]].remove(n_object['id'])
+            
+            if node_dict is not None:
+                node_dict['has_sequence'] = True
+                node_dict['sequence_status'] = 'TNA-eligible'
+                if 'poor_quality' in best_record:
+                    try:
+                        node_dict['poor_quality'] = int(best_record['poor_quality'])
+                    except ValueError:
+                        pass
+                if 'fraction_ambig' in best_record:
+                    try:
+                        node_dict['fraction_ambig'] = float(best_record['fraction_ambig'])
+                    except ValueError:
+                        pass
+                if 'TNA_eligible' in best_record:
+                    try:
+                        node_dict['TNA_eligible'] = int(best_record['TNA_eligible'])
+                    except ValueError:
+                        pass
     elif import_settings.full_inject:  # If full-inject is enabled, construct a new node
+        # For injected nodes, choose the first record (all records are per-sequence)
+        best_record = records[0]
+            
         new_node = {
             "id": node_key,
             node_attribute_key: {}
         }
         node_dict = new_node[node_attribute_key]
-        for k, val in values.items():
+        for k, val in best_record.items():
             if k in field_transformations:
                 store_this = field_transformations[k](val)
                 if store_this is not None:
                     node_dict[field_names[k]] = store_this
+        
+        has_seq = check_has_sequence(best_record)
+        node_dict['has_sequence'] = has_seq
+        node_dict['sequence_status'] = 'TNA-eligible' if has_seq else 'none'
+        
+        if has_seq:
+            if 'poor_quality' in best_record:
+                try:
+                    node_dict['poor_quality'] = int(best_record['poor_quality'])
+                except ValueError:
+                    pass
+            if 'fraction_ambig' in best_record:
+                try:
+                    node_dict['fraction_ambig'] = float(best_record['fraction_ambig'])
+                except ValueError:
+                    pass
+            if 'TNA_eligible' in best_record:
+                try:
+                    node_dict['TNA_eligible'] = int(best_record['TNA_eligible'])
+                except ValueError:
+                    pass
+        
         injected_nodes.append(new_node)
 
 if import_settings.full_inject and len(injected_nodes) > 0:
-    # 1. Record original mapping of old index -> node ID to remap edge indices
-    index_to_id = {i: node["id"] for i, node in enumerate(network_json["Nodes"])}
-    
-    # 2. Append newly injected nodes
+    # 1. Append newly injected nodes
     network_json["Nodes"].extend(injected_nodes)
+    
+    # 2. Tag each node with its pre-sort index
+    for i, node in enumerate(network_json["Nodes"]):
+        node["__temp_index__"] = i
     
     # 3. Sort all nodes alphabetically by ID to take advantage of Front (prefix) compression
     network_json["Nodes"] = sorted(network_json["Nodes"], key=lambda x: x["id"])
     
-    # 4. Build mapping of node ID -> new index
-    id_to_new_index = {node["id"]: i for i, node in enumerate(network_json["Nodes"])}
+    # 4. Build mapping of old index -> new sorted index
+    old_to_new_index = {node["__temp_index__"]: i for i, node in enumerate(network_json["Nodes"])}
     
-    # 5. Remap Edges source/target indices to match the new sorted node order
+    # 5. Clean up temporary index tag
+    for node in network_json["Nodes"]:
+        del node["__temp_index__"]
+    
+    # 6. Remap Edges source/target indices to match the new sorted node order
     for edge in network_json.get("Edges", []):
-        source_id = index_to_id[edge["source"]]
-        target_id = index_to_id[edge["target"]]
-        edge["source"] = id_to_new_index[source_id]
-        edge["target"] = id_to_new_index[target_id]
+        edge["source"] = old_to_new_index[edge["source"]]
+        edge["target"] = old_to_new_index[edge["target"]]
 
 print ("\nImport summary", file = sys.stderr)
 print ("\t Records in file  : %d" % total_records, file = sys.stderr)
@@ -275,13 +374,52 @@ print ("\n", file = sys.stderr)
 if inject_missing_value:
     for values in inject_missing_value:        
         for node_id in uninjected_set[values[0]]:
-            node_dict = ensure_key (nodes_indexed_by_id[node_id], node_attribute_key)
+            node_dict = ensure_key (nodes_by_full_id[node_id], node_attribute_key)
             node_dict[values[0]] = values[1]
 
 
 if import_settings.inplace and import_settings.network is not sys.stdin:
     import_settings.output = open (import_settings.network.name, "w")
     
+if network_attribute_key in network_json:
+    if 'has_sequence' not in network_json[network_attribute_key]:
+        network_json[network_attribute_key]['has_sequence'] = {
+            'name': 'has_sequence',
+            'type': 'Boolean',
+            'label': 'Has Sequence'
+        }
+    if 'sequence_status' not in network_json[network_attribute_key]:
+        network_json[network_attribute_key]['sequence_status'] = {
+            'name': 'sequence_status',
+            'type': 'String',
+            'label': 'Sequence Status'
+        }
+    if 'poor_quality' not in network_json[network_attribute_key]:
+        network_json[network_attribute_key]['poor_quality'] = {
+            'name': 'poor_quality',
+            'type': 'Number',
+            'label': 'poor_quality'
+        }
+    if 'fraction_ambig' not in network_json[network_attribute_key]:
+        network_json[network_attribute_key]['fraction_ambig'] = {
+            'name': 'fraction_ambig',
+            'type': 'Number',
+            'label': 'fraction_ambig'
+        }
+    if 'TNA_eligible' not in network_json[network_attribute_key]:
+        network_json[network_attribute_key]['TNA_eligible'] = {
+            'name': 'TNA_eligible',
+            'type': 'Number',
+            'label': 'TNA_eligible'
+        }
+
+for n in network_json["Nodes"]:
+    node_dict = ensure_key(n, node_attribute_key)
+    if 'has_sequence' not in node_dict:
+        node_dict['has_sequence'] = True
+    if 'sequence_status' not in node_dict:
+        node_dict['sequence_status'] = 'TNA-eligible'
+
 if 'Settings' in network_json and 'compact_json' in network_json['Settings'] and network_json['Settings']['compact_json']:
      ht_compress_network_json (network_json)
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='hivclustering',
       package_data={'hivclustering': [
             'data/HBL/*.bf',
     ]},
-    python_requires='>=3.10',
+    python_requires='>=3.9',
     extras_require={
         'edgefiltering': ['hyphy-python >= 0.1.11','hppy >= 0.9.9'],
     },

--- a/tests/test_hivnetworkannotate.py
+++ b/tests/test_hivnetworkannotate.py
@@ -295,6 +295,93 @@ class TestHivnetworkannotateTraceResults(unittest.TestCase):
             os.unlink(fields_path)
             os.unlink(output_path)
 
+    def test_duplicate_attributes_with_sequence_matching(self):
+        """Test that duplicate attributes matching selects the correct row using sequence ID tokens."""
+        # Patient 1 has two entries in attributes:
+        # - Entry A: has sequence (TNA_eligible = 1), document_uid = seq1, lab_seq = 101
+        # - Entry B: no sequence (TNA_eligible = 0), document_uid = seq_no, lab_seq = 102
+        # We check that the node gets annotated with the correct has_sequence = True and lab_seq = 101.
+        network_data = {
+            "Nodes": [
+                {"id": "patient1|seq1"}
+            ],
+            "Edges": []
+        }
+        
+        attributes_data = [
+            {
+                "patient1": "patient1",
+                "document_uid": "seq_no",
+                "lab_seq": "102",
+                "TNA_eligible": "0"
+            },
+            {
+                "patient1": "patient1",
+                "document_uid": "seq1",
+                "lab_seq": "101",
+                "TNA_eligible": "1"
+            }
+        ]
+        
+        fields_data = {
+            "TNA_eligible": {
+                "label": "has_sequence",
+                "type": "String"
+            },
+            "lab_seq": {
+                "label": "lab_seq",
+                "type": "String"
+            },
+            "keying": {
+                "fields": ["patient1"],
+                "delimiter": "|"
+            }
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as network_file:
+            json.dump(network_data, network_file)
+            network_path = network_file.name
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as attr_file:
+            json.dump(attributes_data, attr_file)
+            attr_path = attr_file.name
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as fields_file:
+            json.dump(fields_data, fields_file)
+            fields_path = fields_file.name
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as output_file:
+            output_path = output_file.name
+
+        try:
+            cmd = [
+                sys.executable,
+                os.path.join(os.path.dirname(__file__), '..', 'scripts', 'hivnetworkannotate'),
+                '-n', network_path,
+                '-a', attr_path,
+                '-g', fields_path,
+                '-o', output_path
+            ]
+
+            result = subprocess.run(cmd, capture_output=True, text=True)
+
+            self.assertEqual(result.returncode, 0,
+                           f"Command failed with stderr: {result.stderr}")
+
+            # Read the output and verify structure
+            with open(output_path, 'r') as f:
+                output_json = json.load(f)
+            
+            node = output_json["Nodes"][0]
+            self.assertEqual(node["patient_attributes"]["has_sequence"], True)
+            self.assertEqual(node["patient_attributes"]["lab_seq"], "101")
+
+        finally:
+            os.unlink(network_path)
+            os.unlink(attr_path)
+            os.unlink(fields_path)
+            os.unlink(output_path)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## PR Description: Support Sequence-Token Duplicate Matching, Inject Node Quality Attributes, and Remap Sorted Nodes

This pull request enhances the `hivnetworkannotate` tool to support sequence-token matching for duplicate patient attributes, inject sequence-related metadata/quality fields into node tables, and perform reliable index remapping for sorted/compressed nodes.

### Key Modifications

#### 1. Token-Based Attribute Disambiguation (Duplicate Record Matching)
*   **Multi-Record Support:** Refactored the CSV/JSON importing steps in `scripts/hivnetworkannotate` to group patient attribute records by their patient key in a list (`to_import[key] = [...]`), rather than overwriting previous entries.
*   **Sequence-Token Match Scoring:** Implemented `compute_match_score` to compare a node ID's unique sequence tokens (derived by subtracting the key fields from the full node ID) against fields in duplicate patient records. The record with the highest matching score is selected as the `best_record`, ensuring specific sequence-level attributes (e.g. collection date, laboratory sequence IDs) map to the correct node in cases where a patient has multiple records.
*   **Default Fallback:** Defaults to the first record (`records[0]`) if no matching tokens are found.

#### 2. Sequence Presence and Data Quality Injection
*   **Sequence Status Flags:** Populates `has_sequence` (Boolean) and `sequence_status` (String, e.g. `'TNA-eligible'` or `'none'`) on all nodes.
*   **Metadata Integration:** Safely parses and injects key data quality metrics (`poor_quality`, `fraction_ambig`, and `TNA_eligible`) from patient records directly into the node's patient attribute dictionary.
*   **Predefined Attribute Properties Schema:** Ensures that standard schema headers for `has_sequence`, `sequence_status`, `poor_quality`, `fraction_ambig`, and `TNA_eligible` are appended to the network's schema properties if missing.

#### 3. Index Remapping for Alphabetically Sorted Nodes
*   **Alphabetic Node Sorting:** Sorted nodes alphabetically by ID to maximize front (prefix) compression efficiency for the down-stream visualizer.
*   **Temporary Index Mapping:** Tagged each node with a temporary `__temp_index__` before sorting. This provides a robust map of `old_index -> new_sorted_index` to safely update edge source and target indices, avoiding topology breaks from index drift.

#### 4. Setup and Compatibility Updates
*   **Python Compatibility:** Relaxed `python_requires` in `setup.py` from `>=3.10` to `>=3.9` to widen deployment environment compatibility.

#### 5. Verification and Unit Testing
*   Added `test_duplicate_attributes_with_sequence_matching` in `tests/test_hivnetworkannotate.py` to assert correct matching behavior for patients with duplicate attribute entries (e.g., sequenced vs. unsequenced records).
*   Verified that all 5 test suites pass successfully.